### PR TITLE
Fix negative range label in NAV plot

### DIFF
--- a/NAV_kasv.R
+++ b/NAV_kasv.R
@@ -79,7 +79,7 @@ navid_kuu_epi <- navid_kuu %>%
 
 navid_kuu_pikk <- navid_kuu_pikk %>%
   mutate(value_cut = cut(value, c(-10, 0, 10, 20,30, 40))) %>%
-  mutate(value_cut = fct_recode(value_cut, ">0%" = "(-10,0]"))
+  mutate(value_cut = fct_recode(value_cut, "<=0%" = "(-10,0]"))
 
 
 p <- navid_kuu_pikk %>%


### PR DESCRIPTION
## Summary
- label negative returns as `<=0%` when binning `value_cut`

## Testing
- `git status --short`