### PR TITLE
Fix Luminor A fund name

### DIFF
--- a/Pensionifondid.csv
+++ b/Pensionifondid.csv
@@ -6,7 +6,7 @@ id,fond,indeks
 46,LHV Pensionifond S,
 38,LHV Pensionifond XL,
 59,LHV Pensionifond XS,
-48,Luminor A Pensionifon,
+48,Luminor A Pensionifond,
 57,Luminor A Pluss Pensionifond,
 49,Luminor B Pensionifond,
 50,Luminor C Pensionifond,


### PR DESCRIPTION
## Summary
- correct typo in `Pensionifondid.csv`

## Testing
- `grep -n "Luminor" Pensionifondid.csv`