### PR TITLE
Remove unused DT and ggalt libraries

### DIFF
--- a/turuylevaade.qmd
+++ b/turuylevaade.qmd
@@ -29,8 +29,6 @@ execute:
 library(tidyverse)
 library(hrbrthemes)
 library(plotly)
-library(DT)
-library(ggalt)
 library(jsonlite)
 library(rvest)
 ```


### PR DESCRIPTION
## Summary
- clean up `turuylevaade.qmd` by removing `library(DT)` and `library(ggalt)`

## Testing
- `quarto --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68867ee2881883258e233f6ff3508966