### PR TITLE
Remove redundant fetch in turuylevaade

### DIFF
--- a/turuylevaade.qmd
+++ b/turuylevaade.qmd
@@ -1401,14 +1401,4 @@ p
 :::
 
 
-```{r}
-# Tõmba alla ja salvesta turu ajalugu
-now_unix <- as.numeric(Sys.time())
-
-data <- fromJSON(paste0("https://www.pensionikeskus.ee/ws/et/stats/fund-pev/2005-08-03?_=", now_unix))
-period_end <- data$period_info$end
-# Edaspidi loe oma failist
-
-
-```
 


### PR DESCRIPTION
## Summary
- delete the closing chunk that re-fetched fund-pev data
- keep earlier period_end calculation

## Testing
- `grep -n "fund-pev" -n -A2 -B2 turuylevaade.qmd | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6886803bc69083258fb83fdd0e7ff9c1