### PR TITLE
Fix quantmod usage in tuleva

### DIFF
--- a/tuleva.qmd
+++ b/tuleva.qmd
@@ -24,6 +24,7 @@ library(hrbrthemes)
 library(tidyquant)
 library(tseries)
 library(xts)
+library(quantmod)
 hrbrthemes::import_roboto_condensed()
 ```
 


### PR DESCRIPTION
## Summary
- load `quantmod` in `tuleva.qmd` so `getSymbols` works

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688684577930832585888d01f9f64220