### PR TITLE
Load smaller tidyverse subset

### DIFF
--- a/NAV_kasv.R
+++ b/NAV_kasv.R
@@ -1,7 +1,13 @@
 # Load required packages
 library(httr)
 library(jsonlite)
-library(tidyverse)
+library(dplyr)
+library(tidyr)
+library(forcats)
+library(ggplot2)
+library(readr)
+library(stringr)
+library(lubridate)
 library(hrbrthemes)
 library(ggfittext)
 

--- a/run-turuylevaade.yml
+++ b/run-turuylevaade.yml
@@ -36,7 +36,13 @@ jobs:
         with:
           extra-packages: |
             any::ssh,          # script does its own scp/ssh
-            any::tidyverse,    # example – remove if not needed
+            any::dplyr,
+            any::tidyr,
+            any::forcats,
+            any::ggplot2,
+            any::readr,
+            any::stringr,
+            any::lubridate,
             any::hrbrthemes,
             any::ggfittext,
             any::tidyquant,

--- a/tuleva.qmd
+++ b/tuleva.qmd
@@ -19,7 +19,13 @@ execute:
 
 
 ```{r}
-library(tidyverse)
+library(dplyr)
+library(tidyr)
+library(forcats)
+library(ggplot2)
+library(readr)
+library(stringr)
+library(lubridate)
 library(hrbrthemes)
 library(tidyquant)
 library(tseries)

--- a/turuylevaade.qmd
+++ b/turuylevaade.qmd
@@ -26,7 +26,13 @@ execute:
 
 
 ```{r message=FALSE}
-library(tidyverse)
+library(dplyr)
+library(tidyr)
+library(forcats)
+library(ggplot2)
+library(readr)
+library(stringr)
+library(lubridate)
 library(hrbrthemes)
 library(plotly)
 library(jsonlite)


### PR DESCRIPTION
## Summary
- load specific tidyverse packages instead of the full collection in `turuylevaade.qmd`, `tuleva.qmd` and `NAV_kasv.R`
- mirror these dependencies in the GitHub Actions workflow

## Testing
- `Rscript -e "library(dplyr);library(tidyr);sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886fdd166e48325be0348320b28ff39